### PR TITLE
Update to Compose 1.0.0-beta03

### DIFF
--- a/pulltorefresh/build.gradle
+++ b/pulltorefresh/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext.kotlin_version = '1.4.30'
     ext {
-        compose_version = '1.0.0-beta01'
+        compose_version = '1.0.0-beta03'
     }
     repositories {
         google()


### PR DESCRIPTION
There seems to have been an internal ABI change between beta01 and beta03 which causes apps compiling with Compose beta03 to fail at runtime if they use PullToRefresh. To confirm beta03 fixes the problem, I've [vendored](https://msfjarvis.dev/g/compose-lobsters/pr/179) PullToRefresh in my app and that fixed the crash without any changes in the actual code